### PR TITLE
Move parse code

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -71,7 +71,8 @@ app.run(function($rootScope, toolbar, toolbarItems, appMenuService) {
                 }
             ]
         },
-        {
+        //TODO: temporarily bugged
+        /*{
             type: "buttonGroup",
             buttons: [
                 {
@@ -93,7 +94,7 @@ app.run(function($rootScope, toolbar, toolbarItems, appMenuService) {
                     }
                 }
             ]
-        },
+        },*/
         {
             id: toolbarItems.LABEL_NODES,
             caption: 'Show Labels',

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -108,7 +108,7 @@ app.run(function($rootScope, toolbar, toolbarItems, appMenuService) {
             caption: 'Reoptimize',
             icon: 'icon acmacs-optimize',
             callback: function () {
-                $rootScope.$broadcast('api.reoptimize');
+                $rootScope.$broadcast('map.reOptimize');
             }
         },{
             id: toolbarItems.DISABLE_MAP2,

--- a/src/app/components/filehandling/fileHandlingService.js
+++ b/src/app/components/filehandling/fileHandlingService.js
@@ -45,7 +45,7 @@
             handleFileOpen: handleFileOpen,
             handleFileSaveAs: handleFileSaveAs,
             reOptimize: reOptimize,
-            getErrorConnectionlines: getErrorConnectionlines,
+            getErrorConnectionLines: getErrorConnectionLines,
             disableNodes: disableNodes,
             disableNodesWithouhtStress: disableNodesWithouhtStress,
             createNewFileFromAlreadyExistingOne: createNewFileFromAlreadyExistingOne
@@ -145,8 +145,8 @@
                         ]).then(function(data) {
                             var result = {};
                             result.table = JSON.parse(data[0]);
-                            result.map   = JSON.parse(data[1]);
-                            acd1File = output.output_acd1;
+                            result.map   = parseLayoutData(JSON.parse(data[1]));
+                            result.acd1File = output.output_acd1;
                             return result;
                         });
                     }, function (reason) {
@@ -162,14 +162,13 @@
          * Calls api to re-optimize (relax) the map
          * @param mapData
          */
-        function reOptimize(mapData, pointsMoved) {
+        function reOptimize(mapData, acd1, pointsMoved) {
             cfpLoadingBar.start();
 
             // check if a node is moved
-            if (pointsMoved === true)
-            {
+            if (pointsMoved === true) {
                 var list = [];
-                mapData.d3Nodes.forEach(function (layout, i) {
+                mapData.layout.forEach(function (layout, i) {
                     list[i] = [
                         layout.x,
                         layout.y
@@ -177,46 +176,43 @@
                 });
                 var additional_params = {
                     coordinates: list,
-                    projection: projection
+                    projection: acd1.projection
                 };
 
-                api.new_projection(additional_params, acd1File)
+                return api.new_projection(additional_params, acd1.acd1File)
                     .then(function (output) {
                         var output_json = output.output_json;
-                        acd1File = output.output_acd1;
+                        acd1.acd1File = output.output_acd1;
                         var output_data = fs.readFileSync(output_json, 'utf8');
                         var mapJsonData = JSON.parse(output_data);
-                        projection = mapJsonData.projection;
-                        relax_existing(mapData);
+                        acd1.projection = mapJsonData.projection;
+                        return relax_existing(mapData, acd1);
                     }, function (reason) {
                         return errorReason(reason);
                     });
             } else {
-                relax_existing(mapData);
+                return relax_existing(mapData, acd1);
             }
 
         }
 
-        function relax_existing(mapData)
+        function relax_existing(mapData, acd1)
         {
             var relax_additional_params = {
-                projection: projection
+                projection: acd1.projection
             };
-            api.relax_existing(relax_additional_params, acd1File)
+            return api.relax_existing(relax_additional_params, acd1.acd1File)
                 .then(function (filename) {
-                    acd1File = filename.updated_acd1;
-                    var map_additional_params = {projection: projection};
-                    api.execute(api.get_commands().GET_MAP, map_additional_params, acd1File)
+                    acd1.acd1File = filename.updated_acd1;
+                    var map_additional_params = {projection: acd1.projection};
+                    return api.execute(api.get_commands().GET_MAP, map_additional_params, acd1.acd1File)
                         .then(function (filename) {
-                            var output_json = filename;
-                            fs.readFile(output_json, 'utf8', function (err, data) {
-                                var mapJsonData = JSON.parse(data);
-                                mapData.stress = mapJsonData.stress;
-                                mapJsonData.map.layout.forEach(function (layout, i) {
-                                    mapData.d3Nodes[i].x = layout[0];
-                                    mapData.d3Nodes[i].y = layout[1];
-                                });
+                            return $q.all([
+                                readFile(filename)
+                            ]).then(function(data) {
+                                mapData = parseLayoutData(JSON.parse(data));
                                 cfpLoadingBar.complete();
+                                return mapData;
                             });
                         }, function (reason) {
                             return errorReason(reason);
@@ -226,10 +222,95 @@
                 });
         }
 
+
+        /**
+         * Creates the data structure of the map data object and returns it.
+         * @param data
+         * @returns {{
+         *      stress: Number,
+         *      layout: Array,
+         *      d3ConnectionLines: Array,
+         *      d3ErrorLines: Array
+         * }}
+         */
+        function parseLayoutData (data) {
+
+            var oldMap = data.map;
+
+            if (_.isUndefined(oldMap)) {
+                //TODO: Throw error what went wrong
+                return {};
+            }
+
+            var newData = {};
+            newData.layout = [];
+            newData.d3ConnectionLines = [];
+            newData.d3ErrorLines = [];
+            newData.stress = data.stress;
+
+            oldMap.layout.forEach(function (layout, i) {
+                newData.layout[i] = {
+                    "x": layout[0],
+                    "y": layout[1],
+                    "id": i
+                };
+            });
+
+            oldMap.point_info.forEach(function (point_info, i) {
+
+                var node_name = "undefined";
+
+                if (!_.isUndefined(point_info.name)) {
+                    node_name = point_info.name;
+                }
+
+                newData.layout[i].name = node_name;
+            });
+
+            oldMap.styles.points.forEach(function (point, i) {
+                newData.layout[i].style = oldMap.styles.styles[point];
+            });
+
+            // checking if the drawing order is available
+            if (!_.isUndefined(oldMap.styles.drawing_order)) {
+
+                // In case the drawing_order is defined, we order the nodes based on their drawing order.
+                var order_list = oldMap.styles.drawing_order[0].concat(oldMap.styles.drawing_order[1]);
+                var length = order_list.length;
+
+                // start a bubble sort.
+                // The start of the sorting of drawing order following Bubble sort algorithm
+                for (var i = 0; i < length; i++) {
+
+                    for (var j = (length - 1); j > 0; j--) {
+
+                        if (order_list[j] < order_list[j - 1]) {
+
+                            // swapping the order_list  to keep the reference
+                            var temp = order_list[j - 1];
+                            order_list[j - 1] = order_list[j];
+                            order_list[j] = temp;
+
+                            // swapping the data
+                            temp = newData.layout[j - 1];
+                            newData.layout[j - 1] = newData.layout[j];
+                            newData.layout[j] = temp;
+
+                        }
+
+                    }
+
+                }
+
+            }
+
+            return newData;
+        }
+
         /**
          * Calls api to get data for error and connection lines
          */
-        function getErrorConnectionlines(mapData){
+        function getErrorConnectionLines(mapData, acd1){
 
             var result = {
                 d3ErrorLines: [],
@@ -240,12 +321,11 @@
 
             //TODO set projection number from scope
             var additional_params = {};
-            return api.execute(api.get_commands().ERROR_LINES, additional_params, acd1File).then(function (filename) {
+            return api.execute(api.get_commands().ERROR_LINES, additional_params, acd1.acd1File).then(function (filename) {
                 fs.readFile(filename, 'utf8', function (err, data) {
                     var mapJsonData = JSON.parse(data);
                     // relax returns array of error_lines.
-                    mapData.map.error_lines = mapJsonData.error_lines;
-                    calculateLines(mapData.map.error_lines, mapData.map.layout, result); //TODO: why first apply to scope? then calculate??
+                    calculateLines(mapJsonData.error_lines, mapData.layout, result);
                     cfpLoadingBar.complete();
                 });
                 return result;

--- a/src/app/components/filehandling/fileHandlingService.js
+++ b/src/app/components/filehandling/fileHandlingService.js
@@ -38,9 +38,6 @@
 
     function fileHandling ($q, api, Flash, cfpLoadingBar, $timeout) {
 
-        var acd1File = null;
-        var projection = 0;
-
         return {
             handleFileOpen: handleFileOpen,
             handleFileSaveAs: handleFileSaveAs,
@@ -91,7 +88,8 @@
                 extension = "save";
             }
             var additional_params = {format: extension.toString(), filename: filename};
-            return api.export(acd1File, additional_params).then(function (output) {
+            var acd1file = "abc"; //TODO: THIS NEEDS FIXING. As acd1File isn't stored globally anymore, only acd1 from currently active ng-map should be used here.
+            return api.export(acd1file, additional_params).then(function (output) {
                 cfpLoadingBar.complete();
             }, function (reason) {
                 return errorReason(reason);
@@ -122,7 +120,7 @@
                         var result = {};
                         result.table = JSON.parse(data[0]);
                         result.map   = JSON.parse(data[1]);
-                        acd1File = output.output_acd1;
+                        result.acd1File = output.output_acd1;
                         return result;
                     });
                 });

--- a/src/app/components/filehandling/fileHandlingService.js
+++ b/src/app/components/filehandling/fileHandlingService.js
@@ -47,7 +47,7 @@
             reOptimize: reOptimize,
             getErrorConnectionLines: getErrorConnectionLines,
             disableNodes: disableNodes,
-            disableNodesWithouhtStress: disableNodesWithouhtStress,
+            disableNodesWithoutStress: disableNodesWithoutStress,
             createNewFileFromAlreadyExistingOne: createNewFileFromAlreadyExistingOne
         };
 
@@ -336,11 +336,11 @@
          * Calls api to create a new file from an already existing one n
          * @param mapData and points to remove disabledPoints
          */
-        function createNewFileFromAlreadyExistingOne(mapData, disabledPoints) {
+        function createNewFileFromAlreadyExistingOne(mapData, acd1, disabledPoints) {
             cfpLoadingBar.start();
 
             var disable_additional_params = {
-                projection: projection,
+                projection: acd1.projection,
                 disconnected: disabledPoints
             };
             console.log(disabledPoints);
@@ -350,11 +350,11 @@
             });
             console.log(disabledPoints);
 
-            api.set_disconnected_points(disable_additional_params, acd1File)
+            api.set_disconnected_points(disable_additional_params, acd1.acd1File)
                 .then(function (filename) {
                     var new_acd1 = filename.updated_acd1;
                     var relax_additional_params = {
-                        projection: projection
+                        projection: acd1.projection
                     };
                     api.relax_existing(relax_additional_params, new_acd1)
                         .then(function (filename) {
@@ -378,11 +378,11 @@
          * Calls api to disable nodes (without Sress) from a specific  map
          * @param mapData
          */
-        function disableNodesWithouhtStress(mapData, disabledPoints) {
+        function disableNodesWithoutStress(mapData, acd1, disabledPoints) {
             cfpLoadingBar.start();
 
             var disable_additional_params = {
-                projection: projection,
+                projection: acd1.projection,
                 unmovable: disabledPoints
             };
             //console.log(disabledPoints);
@@ -392,9 +392,9 @@
             });
 
 
-            api.set_unmovable_points(disable_additional_params, acd1File)
+            api.set_unmovable_points(disable_additional_params, acd1.acd1File)
                 .then(function (filename) {
-                    acd1File = filename.updated_acd1;
+                    acd1.acd1File = filename.updated_acd1;
 
 
                     var output_json = filename.output_json;
@@ -417,11 +417,11 @@
          * Calls api to disable nodes from a specific  map
          * @param mapData
          */
-        function disableNodes(mapData, disabledPoints) {
+        function disableNodes(mapData, acd1, disabledPoints) {
             cfpLoadingBar.start();
 
             var disable_additional_params = {
-                projection: projection,
+                projection: acd1.projection,
                 disconnected: disabledPoints
             };
             //console.log(disabledPoints);
@@ -432,30 +432,30 @@
             //console.log(disabledPoints);
 
 
-            api.set_disconnected_points (disable_additional_params, acd1File)
+            api.set_disconnected_points (disable_additional_params, acd1.acd1File)
                 .then(function (filename) {
-                    acd1File = filename.updated_acd1;
+                    acd1.acd1File = filename.updated_acd1;
 
 
                     var output_json = filename.output_json;
 
                     var output_data = fs.readFileSync(output_json, 'utf8');
                     //mapData.stress = mapJsonData.stress;
-                    var map_additional_params = {projection: projection};
-                    api.execute(api.get_commands().GET_MAP, map_additional_params, acd1File)
+                    var map_additional_params = {projection: acd1.projection};
+                    api.execute(api.get_commands().GET_MAP, map_additional_params, acd1.acd1File)
                         .then(function (filename) {
                             var output_json = filename;
                             fs.readFile(output_json, 'utf8', function (err, data) {
                                 var mapJsonData = JSON.parse(data);
                                 mapData.stress = mapJsonData.stress;
                                 mapJsonData.map.layout.forEach(function (layout, i) {
-                                    mapData.d3Nodes[i].x = layout[0];
-                                    mapData.d3Nodes[i].y = layout[1];
+                                    mapData.layout[i].x = layout[0];
+                                    mapData.layout[i].y = layout[1];
                                 });
 
                                 var newfile = "/home/idrissou/malikou.acd1";
                                 var additional_params = {format: 'acd1', filename: newfile};
-                                return api.export(acd1File, additional_params).then(function (filename) {
+                                return api.export(acd1.acd1File, additional_params).then(function (filename) {
                                     cfpLoadingBar.complete();
                                 }, function (reason) {
                                     return errorReason(reason);
@@ -474,8 +474,13 @@
 
         }
 
+
         /**
          * Calculate error and connection lines
+         * @param errorlines
+         * @param layout
+         * @param result
+         * @returns {boolean}
          */
         function calculateLines(errorlines, layout, result) {
             var positive,

--- a/src/app/components/map/mapController.js
+++ b/src/app/components/map/mapController.js
@@ -43,6 +43,7 @@
          */
         $scope.$on('map.reOptimize', function () {
             fileHandling.reOptimize($scope.data, $scope.acd1, $scope.pointsMoved).then(function (result) {
+                $scope.pointsMoved = false;
                 $scope.data = result;
             });
         });

--- a/src/app/components/map/mapController.js
+++ b/src/app/components/map/mapController.js
@@ -1,23 +1,23 @@
 /*
- Antigenic Cartography for Desktop
- [Antigenic Cartography](http://www.antigenic-cartography.org/) is the process of creating maps of antigenically variable pathogens.
- In some cases two-dimensional maps can be produced which reveal interesting information about the antigenic evolution of a pathogen.
- This project aims at providing a desktop application for working with antigenic maps.
+    Antigenic Cartography for Desktop
+    [Antigenic Cartography](http://www.antigenic-cartography.org/) is the process of creating maps of antigenically variable pathogens.
+    In some cases two-dimensional maps can be produced which reveal interesting information about the antigenic evolution of a pathogen.
+    This project aims at providing a desktop application for working with antigenic maps.
 
- © 2015 The Antigenic Cartography Group at the University of Cambridge
+    © 2015 The Antigenic Cartography Group at the University of Cambridge
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 (function() {
@@ -43,7 +43,6 @@
          */
         $scope.$on('map.reOptimize', function () {
             fileHandling.reOptimize($scope.data, $scope.acd1, $scope.pointsMoved).then(function (result) {
-                console.log("reoptimize done");
                 $scope.data = result;
             });
         });
@@ -54,8 +53,8 @@
          */
         $rootScope.$on('api.geterrorlines', function () {
             if ($rootScope.errorlinesShown !== true) {
-                $scope.d3Data.d3Errorlines = [];
-                $scope.d3Data.d3Connectionlines = [];
+                $scope.data.d3Errorlines = [];
+                $scope.data.d3Connectionlines = [];
 
                 getErrorConnectionLines();
             }
@@ -66,7 +65,7 @@
          */
         $scope.$on('api.set_disconnected_points', function () {
             if ($rootScope.disableArrayFlag == true) {
-                fileHandling.disableNodes($scope.d3Data, $rootScope.disableArray);
+                fileHandling.disableNodes($scope.data, $scope.acd1, $rootScope.disableArray);
             }
 
         });
@@ -75,7 +74,7 @@
          */
         $scope.$on('api.set_disconnected_points2', function () {
             if ($rootScope.disableArrayFlag == true) {
-                fileHandling.disableNodesWithouhtStress($scope.d3Data, $rootScope.disableArray);
+                fileHandling.disableNodesWithoutStress($scope.data,  $scope.acd1,$rootScope.disableArray);
             }
 
         });
@@ -84,7 +83,7 @@
          */
         $scope.$on('newMap.create', function () {
             if ($rootScope.disableArrayFlag == true) {
-                fileHandling.createNewFileFromAlreadyExistingOne($scope.d3Data,$rootScope.disableArray);
+                fileHandling.createNewFileFromAlreadyExistingOne($scope.data, $scope.acd1, $rootScope.disableArray);
             }
         });
         /**
@@ -100,7 +99,7 @@
          * Watches for moved nodes while lines are displayed
          */
         $rootScope.$on('api.nudgeTriggeredErrorlines', function () {
-            fileHandling.reOptimize($scope.d3Data);
+            fileHandling.reOptimize($scope.data);
             getErrorConnectionLines();
         });
     }

--- a/src/app/components/map/mapController.js
+++ b/src/app/components/map/mapController.js
@@ -28,85 +28,24 @@
 
     function mapCtrl ($rootScope, $scope, fileHandling) {
 
-        $scope.d3Data = {
-            d3Nodes: [],
-            stress: null
-        };
-
-        var map = $scope.mapData.map.map;
-
         function getErrorConnectionLines() {
-            fileHandling.getErrorConnectionlines($scope.mapData.map).then(function (result) {
-                $scope.d3Data.d3Errorlines = result.d3ErrorLines;
-                $scope.d3Data.d3Connectionlines = result.d3ConnectionLines;
+            fileHandling.getErrorConnectionLines($scope.data, $scope.acd1).then(function (result) {
+                $scope.data.d3Errorlines = result.d3ErrorLines;
+                $scope.data.d3Connectionlines = result.d3ConnectionLines;
             });
         }
 
-
-
-        if (map) {
-
-            if (_.isUndefined($scope.mapData.map)) {
-                return;
-            }
-
-            $scope.d3Data.stress = $scope.mapData.map.stress;
-
-            map.layout.forEach(function (layout, i) {
-                $scope.d3Data.d3Nodes[i] = {
-                    "x": layout[0],
-                    "y": layout[1]
-                };
-            });
-
-            map.point_info.forEach(function (point_info, i) {
-
-                var node_name = "undefined";
-
-                if (!_.isUndefined(point_info.name)) {
-                    node_name = point_info.name;
-                }
-                $scope.d3Data.d3Nodes[i].name = node_name;
-                $scope.d3Data.d3Nodes[i].id=i;
-            });
-
-            map.styles.points.forEach(function (point, i) {
-                $scope.d3Data.d3Nodes[i].style = map.styles.styles[point];
-            });
-
-            // checking if the drawing order is available
-            if (!_.isUndefined(map.styles.drawing_order)) {
-                // In case the drawing_order is defined, we order the nodes based on their drawing order.
-                var order_list = map.styles.drawing_order[0].concat(map.styles.drawing_order[1]);
-                var length = order_list.length;
-                if ($scope.d3Data.d3Nodes.length === length) {
-                    // start a bubble sort.
-                    // The start of the sorting of drawing order following Bubble sort algorithm
-                    for (var i = 0; i < length; i++) {
-                        for (var j = (length - 1); j > 0; j--) {
-                            if (order_list[j] < order_list[j - 1]) {
-                                // swapping the order_list  to keep the reference
-                                var temp = order_list[j - 1];
-                                order_list[j - 1] = order_list[j];
-                                order_list[j] = temp;
-                                // swapping the data
-                                temp = $scope.d3Data.d3Nodes[j - 1];
-                                $scope.d3Data.d3Nodes[j - 1] = $scope.d3Data.d3Nodes[j];
-                                $scope.d3Data.d3Nodes[j] = temp;
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
         /********************* LISTENERS ********************/
 
         /**
          * Watches for a the reoptimize button
          */
-        $scope.$on('api.reoptimize', function () {
-            fileHandling.reOptimize($scope.d3Data, $rootScope.pointsMoved);
+        $scope.$on('map.reOptimize', function () {
+            fileHandling.reOptimize($scope.data, $scope.acd1, $scope.pointsMoved).then(function (result) {
+                console.log("reoptimize done");
+                $scope.data = result;
+            });
         });
 
 

--- a/src/app/shared/appController.js
+++ b/src/app/shared/appController.js
@@ -69,6 +69,10 @@ angular.module('acjim')
                     $scope.tableData = result.table;
                     $scope.openMaps.push({
                         data: result.map,
+                        acd1: {
+                            acd1File: result.acd1File,
+                            projection: result.projection || 0
+                        },
                         options: {
                             id: $scope.openMaps.length,
                             x: 100 * position,

--- a/src/window.html
+++ b/src/window.html
@@ -28,7 +28,7 @@
 
             <div ui-layout-container>
                 <ng-html-window ng-repeat="map in openMaps" options="map.options">
-                    <div class="fullsize" ac-map map="map.data"></div>
+                    <div class="fullsize" d3-map data="map.data" acd1="map.acd1"></div>
                 </ng-html-window>
 
             </div>


### PR DESCRIPTION
Closes #147

d3 layout data now comes already parsed to the mapCtrl. The structure of the new data object is as follows:
```javascript
$scope.data = {
   layout: Array,
   stress: Number,
   d3ErrorLines: Array,
   d3ConnectionLines: Array
}
```
Additionally, the acd1 file and projection number are stored alongside the ng-map. They can be accessed over:
```javascript
$scope.acd1 = {
   acd1file: String,
   projection: Number
}
```
Disabled error line buttons as they are still causing errors.

@rohankoid: Because I moved the acd1 from a global variable in fileHandling to the ng-maps, the file saving will not work anymore:
https://github.com/acjim/AcmacsDesktop/blob/master/src/app/components/filehandling/fileHandlingService.js#L94