### PR TITLE
Remove possibility to open empty windows

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,8 +14,7 @@
 
     <div class="col col-first">
         <ul class="m-new">
-            <li><a ng-click="openDocumentWindow()">New Project</a></li>
-            <li><a ng-click="openFile()">Open</a></li>
+            <li><a ng-click="openFile()">Open File</a></li>
             <li>Open a Recent Project
                 <ul>
                     <li ng-repeat="project in recentProjects | limitTo:5">


### PR DESCRIPTION
Error in #227 does not occur when no window without a file is opened. As this is no functionality we need, the possibility to open a new window can be removed and the issue is no longer relevant.
Closes #227 